### PR TITLE
autoprefixerのコマンドが別にあるので、sassコンパイル時にautoprefixerを動作させなくてもいいのかな〜と思いました。

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,9 +27,6 @@ gulp.task( 'sass' , function(){
 	gulp.src( rootPaths.sassRoot )
 		.pipe(plumber())
 		.pipe(sass({outputStyle: 'expanded'}))
-		.pipe($.autoprefixer({
-	      browsers: ['last 2 versions']
-	    }))
 		.pipe(gulp.dest('./css/'))
 		.pipe(bs.reload({
 	      stream: true,


### PR DESCRIPTION
すみません。
動作テストはしてないです。
申し訳ない。

内容はコミットコメントに書いてある通りであります！！
必要ある記述でしたら、pullRequestを拒否しておいてください。

よろしくお願いします。